### PR TITLE
Dynamic allocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,17 @@ ifdef DEBUG
 	override CFLAGS += -g -DDEBUG
 endif
 
-override CFLAGS += -std=gnu89 -Wall -pedantic -fPIC -shared
+ifndef FIXED_JSON_TOKEN_NUM
+	JSON_FLAG = -DKII_JSON_FIXED_TOKEN_NUM=128
+else
+	JSON_FLAG = -DKII_JSON_FIXED_TOKEN_NUM=$(FIXED_JSON_TOKEN_NUM)
+endif
+
+ifdef FLEXIBLE_JSON_TOKEN
+	JSON_FLAG =
+endif
+
+override CFLAGS += -std=gnu89 -Wall -pedantic -fPIC -shared $(JSON_FLAG)
 
 SOURCES = $(wildcard src/*.c)
 SOURCES += libs/jsmn/jsmn.c

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-override CFLAGS += -std=gnu89 -Wall -pedantic -fPIC -shared
-
 ifdef DEBUG
-	CFLAGS += -g -DDEBUG
+	override CFLAGS += -g -DDEBUG
 endif
+
+override CFLAGS += -std=gnu89 -Wall -pedantic -fPIC -shared
 
 SOURCES = $(wildcard src/*.c)
 SOURCES += libs/jsmn/jsmn.c

--- a/README.mkd
+++ b/README.mkd
@@ -19,6 +19,57 @@ make
 
 After that, you can find target/libkiijson.so.
 
+## Building Kii JSON with variables
+
+### Debug Build
+```sh
+make DEBUG=1
+```
+
+Debug option (-g) and Debug log enabled.
+
+### Configure KII\_JSON\_FIXED\_TOKEN\_NUM
+
+KII\_JSON\_FIXED\_TOKEN\_NUM  macro is used to manage amount memory used to
+parse JSON when received it from server.
+Memory is allocated on stack.
+By default it is set to 128 in the Makefile.
+To override the value, we provides `FIXED_JSON_TOKEN_NUM` variable.
+```
+make FIXED_JSON_TOKEN_NUM=256
+```
+
+Size of memory allocated by this can be calculated as following.
+```c
+sizeof(kii_json_token_t) * KII\_JSON\_FIXED\_TOKEN\_NUM
+```
+
+### Dynamic memory allocation for JSON parsing
+If you prefer to dynamicaly allocation than fixed memory allocation by
+KII\_JSON\_FIXED\_TOKEN\_NUM, You will build sdk with FLEXIBLE\_JSON\_TOKEN
+variable.
+
+```
+make FLEXIBLE_JSON_TOKEN=1
+```
+
+In this case, you need to implement KII\_JSON\_RESOURCE\_CB function and set the
+pointer to kii\_json\_t struct.
+
+If both KII\_JSON\_FIXED\_TOKEN\_NUM and FLEXIBLE\_JSON\_TOKEN are specified,
+KII\_JSON\_FIXED\_TOKEN\_NUM is ignored.
+
+### Combination of variables
+Only KII\_JSON\_FIXED\_TOKEN\_NUM and FLEXIBLE\_JSON\_TOKEN is exclusive.
+DEBUG and either KII\_JSON\_FIXED\_TOKEN\_NUM or FLEXIBLE\_JSON\_TOKEN
+can be combined.
+
+ex.)
+
+```
+make DEBUG=1 FLEXIBLE_JSON_TOKEN=1
+```
+
 ## Example
 
 If you want to extract "hoo" value from following JSON string:

--- a/src/kii_json.c
+++ b/src/kii_json.c
@@ -19,20 +19,6 @@
 
 #include <kii_json.h>
 
-#ifndef KII_JSON_TOKEN_NUM
-/**
- * @def KII_JSON_TOKEN_NUM
- * @brief Json token size
- *
- * KII_JSON_TOKEN_NUM defines size of JSON can be parsed. By default
- * it is set to 128. If you've got error on JSON parsing in SDK, You
- * can increase the size of KII_JSON_TOKEN_NUM so that avoid error on
- * parsing large JSON. To change the size, please specify the size of
- * KII_JSON_TOKEN_NUM on build.
- */
-#define KII_JSON_TOKEN_NUM 128
-#endif
-
 #define EVAL(f, v) f(v)
 #define TOSTR(s) #s
 #define LONG_MAX_STR EVAL(TOSTR, LONG_MAX)

--- a/unit-test/Makefile
+++ b/unit-test/Makefile
@@ -14,7 +14,7 @@ $(OUTDIR):
 	mkdir -p $@
 
 $(LIBKIIJSON):
-	make -C ../
+	make FLEXIBLE_JSON_TOKEN=1 -C ../
 	cp ../$(LIBKIIJSON) $(OUTDIR)
 
 $(LIBGTEST):


### PR DESCRIPTION
KII_JSON_TOKEN_NUM should not defined implicitly.
If it is not defined, we use dynamic allocation with application implementation invoked by the callback function.
